### PR TITLE
ci: GitHub Workflows: add build & auto-release

### DIFF
--- a/.github/workflows/cmake-build-and-release.yml
+++ b/.github/workflows/cmake-build-and-release.yml
@@ -1,0 +1,95 @@
+name: CMake Build and Release
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  release:
+    types: [created]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ gcc-multilib g++-multilib libc6-dev libc6-dev-i386 lib32gcc-9-dev lib32stdc++-9-dev
+
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: plugin-scf-linux
+          path: build/*.so
+
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: choco install cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+
+      - name: Configure CMake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+      - name: Build
+        run: cmake --build build --config ${{env.BUILD_TYPE}}
+
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: plugin-scf-windows
+          path: build/Release/*.dll
+
+  create_release:
+    needs: [build_linux, build_windows]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get short commit SHA and date
+        id: get_sha_date
+        run: |
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "release_date=$(date -u +%Y-%m-%d)" >> $GITHUB_ENV
+
+      - name: Download Linux artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: plugin-scf-linux
+          path: ./artifacts/linux
+
+      - name: Download Windows artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: plugin-scf-windows
+          path: ./artifacts/windows
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: "build_${{ env.release_date }}_${{ env.short_sha }}"
+          name: "Build: ${{ env.release_date }} / ${{ env.short_sha }}"
+          draft: false
+          prerelease: false
+          files: |
+            artifacts/linux/*
+            artifacts/windows/*
+          file_glob: true
+          generate_release_notes: true


### PR DESCRIPTION
[EN]
Building .dll and .so will now happen on Github Actions automatically on the commit push event.
Also, the release will be automatically published to Github Releases, from where .so and .dll files can be downloaded.

[RU]
Теперь сборка .dll и .so будет происходить на Github Actions автоматически при событии пуша коммита.
Также, будет производится автоматическая публикация релиза на Github Releases, откуда можно будет скачать .so и .dll файлы.

https://github.com/TemaSM/srv-crashfix/releases

![image](https://github.com/user-attachments/assets/97e9c36c-9d14-4f68-a25d-a1466b5d0451)


Closes #1 